### PR TITLE
feat: collapseNodeModules feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -223,6 +223,11 @@
                         "type": "boolean",
                         "default": true
                     },
+                    "features.collapseNodeModules": {
+                        "description": "Automatically collapse node_modules when last file from it was closed",
+                        "type": "boolean",
+                        "default": false
+                    },
                     "typeDecorations.enable": {
                         "type": "boolean",
                         "default": true

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,6 +39,7 @@ import { registerCutLineContentsPreserve } from './features/cutLineContentsPrese
 import typeDecorations from './features/typeDecorations'
 import autoRemoveSemicolon from './features/autoRemoveSemicolon'
 import printDocumentUri from './features/printDocumentUri'
+import collapseNodeModules from './features/collapseNodeModules'
 
 export const activate = () => {
     // preserve camelcase identifiers (only vars for now)
@@ -80,6 +81,7 @@ export const activate = () => {
     typeDecorations()
     autoRemoveSemicolon()
     printDocumentUri()
+    collapseNodeModules()
 
     // vscode.languages.registerSelectionRangeProvider('*', {
     //     provideSelectionRanges(document, positions, token) {
@@ -127,6 +129,8 @@ export const activate = () => {
             },
         ])
     })
+
+    registerActiveDevelopmentCommand(async () => {})
 
     if (getExtensionSetting('enableDebug')) setDebugEnabled(true)
 }

--- a/src/features/collapseNodeModules.ts
+++ b/src/features/collapseNodeModules.ts
@@ -1,0 +1,23 @@
+import * as vscode from 'vscode'
+import { getExtensionSetting } from 'vscode-framework'
+
+export default () => {
+    if (!getExtensionSetting('features.collapseNodeModules')) return
+    vscode.window.tabGroups.onDidChangeTabs(({ closed }) => {
+        const nodeModulesTab = (tab: vscode.Tab) => {
+            const { uri } = tab.input as { uri: vscode.Uri }
+            if (!uri) return
+            return uri.scheme === 'file' && uri.path.includes('node_modules')
+        }
+
+        const closedSome = closed.some(nodeModulesTab)
+        // wait open event e.g. on selecting files in preview: close -> open immediately
+        setTimeout(async () => {
+            const remaining = vscode.window.tabGroups.all.every(tabGroup => tabGroup.tabs.every(tab => !nodeModulesTab(tab)))
+            // eslint-disable-next-line curly
+            if (closedSome && remaining) {
+                await vscode.commands.executeCommand('workbench.files.action.collapseExplorerFolders')
+            }
+        })
+    })
+}


### PR DESCRIPTION
Disabled by default as it can be annoying
In theory it can be useful to toggle globally e.g. on absolutely any tab reselect
To see in action:
1. Go to any file under node_modules
2. Close the file
-> node_modules is collapsed