### PR TITLE
feat(copyVariableName): allow to copy first destructured or imported variable

### DIFF
--- a/src/features/copyVariableName.ts
+++ b/src/features/copyVariableName.ts
@@ -8,7 +8,7 @@ export const registerCopyVariableName = () => {
         // also would make sense to support mutliple selections/cursors
         let varName: string | undefined
         const lineText = activeEditor.document.lineAt(activeEditor.selection.end).text
-        const constName = /\s*(?:const|let|type|interface|import) ([\w\d]+)/.exec(lineText)?.[1]
+        const constName = /\s*(?:const(?: {)?|let(?: {)?|type|interface|import(?: {)?) ([\w\d]+)/.exec(lineText)?.[1]
         varName = constName
         if (!varName) {
             // TODO replaceDocumentation?: (str


### PR DESCRIPTION
Examples of what now possible:
```ts
import { endGroup, startGroup } from '@actions/core' // endGroup
const { document, editor } = stuff // document
```
Just as always cursor can be in any position on the line, first variable is copied into the clipboard