### PR TITLE
feat: stricter type decorations

### DIFF
--- a/package.json
+++ b/package.json
@@ -227,6 +227,14 @@
                         "type": "boolean",
                         "default": true
                     },
+                    "typeDecorations.ignoreValues": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "markdownDescription": "Ignore specific resolved values from type decorations. In future it can be regex if starts & ends with `/`. Examples can be: `any`, `unknown`",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
                     "autoRemoveSemicolon.enable": {
                         "type": "boolean",
                         "default": true

--- a/package.json
+++ b/package.json
@@ -234,6 +234,7 @@
                         "items": {
                             "type": "string"
                         }
+                    },
                     "typeDecorations.enableInStyles": {
                         "type": "boolean",
                         "default": false

--- a/src/features/typeDecorations.ts
+++ b/src/features/typeDecorations.ts
@@ -48,7 +48,7 @@ export default () => {
         const {
             selections: [selection],
         } = textEditor
-        if (!selection || !selection.start.isEqual(selection.end)) return
+        if (!selection || !selection.isEmpty) return
         const pos = selection.end
         const { document } = textEditor
         const lineText = document.lineAt(pos).text

--- a/src/features/typeDecorations.ts
+++ b/src/features/typeDecorations.ts
@@ -44,10 +44,6 @@ export default () => {
             !vscode.languages.match(enableLanguages, textEditor.document)
         )
             return
-        const { selections, document } = textEditor
-        const pos = selections[0]!.end
-        const text = document.lineAt(pos).text.slice(0, pos.character)
-        const match = /(:| =) $/.exec(text)
         textEditor.setDecorations(decoration, [])
         const {
             selections: [selection],
@@ -60,7 +56,7 @@ export default () => {
         const textAfter = lineText.slice(pos.character)
         const match = /(:| =) $/.exec(textBefore)
         // if in destructure or object literal
-        const endingMatch = /^\s*(}|]|;|$)/
+        const endingMatch = /^\s*(}|]|;|,|$)/
         if (!match || !endingMatch.test(textAfter)) return
         const offset = match[0]!.length
         const isInStyles = await checkIfInStyles(document, pos)

--- a/src/features/typeDecorations.ts
+++ b/src/features/typeDecorations.ts
@@ -55,9 +55,10 @@ export default () => {
         const textBefore = lineText.slice(0, pos.character)
         const textAfter = lineText.slice(pos.character)
         const match = /(:| =) $/.exec(textBefore)
+        const isInBannedPosition = /(const|let) (\w|\d)+ = $/i.test(textBefore)
         // if in destructure or object literal
         const endingMatch = /^\s*(}|]|;|,|$)/
-        if (!match || !endingMatch.test(textAfter)) return
+        if (!match || isInBannedPosition || !endingMatch.test(textAfter)) return
         const offset = match[0]!.length
         const isInStyles = await checkIfInStyles(document, pos)
         if (isInStyles && !getExtensionSetting('typeDecorations.enableInStyles')) return

--- a/src/features/typeDecorations.ts
+++ b/src/features/typeDecorations.ts
@@ -4,6 +4,7 @@ import { getExtensionSetting } from 'vscode-framework'
 export default () => {
     if (!getExtensionSetting('typeDecorations.enable')) return
     const enableLanguages = getExtensionSetting('typeDecorations.languages')
+    const ignoreValues = getExtensionSetting('typeDecorations.ignoreValues')
     const decoration = vscode.window.createTextEditorDecorationType({
         after: {
             // https://code.visualstudio.com/api/references/theme-color#editor-colors
@@ -21,13 +22,20 @@ export default () => {
             !vscode.languages.match(enableLanguages, textEditor.document)
         )
             return
-        const { selections } = textEditor
-        const pos = selections[0]!.end
-        const { document } = textEditor
-        const text = document.lineAt(pos).text.slice(0, pos.character)
-        const match = /(:| =) $/.exec(text)
         textEditor.setDecorations(decoration, [])
-        if (!match) return
+        const {
+            selections: [selection],
+        } = textEditor
+        if (!selection || !selection.start.isEqual(selection.end)) return
+        const pos = selection.end
+        const { document } = textEditor
+        const lineText = document.lineAt(pos).text
+        const textBefore = lineText.slice(0, pos.character)
+        const textAfter = lineText.slice(pos.character)
+        const match = /(:| =) $/.exec(textBefore)
+        // if in destructure or object literal
+        const endingMatch = /^\s*(}|]|;|$)/
+        if (!match || !endingMatch.test(textAfter)) return
         const offset = match[0]!.length
         const hoverData: vscode.Hover[] = await vscode.commands.executeCommand('vscode.executeHoverProvider', document.uri, pos.translate(0, -offset))
         let typeString: string | undefined
@@ -44,7 +52,7 @@ export default () => {
             break
         }
 
-        if (!typeString || typeString === '{') return
+        if (!typeString || typeString === '{' || ignoreValues.includes(typeString)) return
         textEditor.setDecorations(decoration, [
             {
                 range: new vscode.Range(pos.translate(0, -1), pos),


### PR DESCRIPTION
- fix: only show decoration if selection is empty
- now decorations showing only in case if there is no existing value
- new settings to filter out some decoration values
- disable after `const` or `let`