### PR TITLE
fix: restrict max tab number

### DIFF
--- a/src/features/tabsWithNumbers.ts
+++ b/src/features/tabsWithNumbers.ts
@@ -117,9 +117,14 @@ export default () => {
                 if (!textEditor || textEditor.viewColumn === undefined) return
                 const { uri } = textEditor.document
                 const elemIndex = recentFileStack.findIndex(tabUri => tabUri.toString() === uri.toString())
-                if (elemIndex === -1) {
+                if (elemIndex === -1 && recentFileStack.length < 9) {
                     recentFileStack.unshift(uri)
                     return
+                }
+
+                if (elemIndex === -1 && mode === 'recentlyOpened') {
+                    recentFileStack.pop()
+                    recentFileStack.unshift(uri)
                 }
 
                 if (mode === 'recentlyFocused') {


### PR DESCRIPTION
@zardoy  Need to think about `fromLeft` setting - restricting max tab number in this case makes little sense as it'll just copy `recentlyOpened` functionality.
Btw, looks like max possible tab displaying number is `99` - I didn't find any restrictions in extension logic but all my attempts of exceeding it were in vain :). Despite it's cool, I can't find a good application for it.