### PR TITLE
fix: hide number in explorer for closed tab

### DIFF
--- a/src/features/tabsWithNumbers.ts
+++ b/src/features/tabsWithNumbers.ts
@@ -99,23 +99,18 @@ export default () => {
         disposables.push(vscode.window.registerFileDecorationProvider(new FileDecorationProvider()))
         if (!recentByMode) {
             disposables.push(
-                vscode.window.tabGroups.onDidChangeTabs(({ opened, changed, closed }) => {
-                    const previewTabs: vscode.Uri[] = []
-                    for (const { isPreview, input } of [...closed, ...opened, ...changed])
-                        if (isPreview && input instanceof vscode.TabInputText) previewTabs.push(input.uri)
+                vscode.window.tabGroups.onDidChangeTabs(({ closed }) => {
+                    const tabsToUri = (tabs: readonly vscode.Tab[]) =>
+                        compact(
+                            tabs.map(({ input }) => {
+                                if (!(input instanceof vscode.TabInputText)) return
+                                return input.uri
+                            }),
+                        )
+                    const allCurrentTabsUris = tabsToUri(vscode.window.tabGroups.activeTabGroup.tabs)
+                    const closedTabsUris = tabsToUri(closed)
 
-                    const updating = compact(
-                        vscode.window.tabGroups.activeTabGroup.tabs.map(({ input }) => {
-                            if (!(input instanceof vscode.TabInputText)) return
-                            return input.uri
-                        }),
-                    )
-                    if (previewTabs.length > 0) {
-                        updateDecorations([...previewTabs, ...updating])
-                        return
-                    }
-
-                    updateDecorations(updating)
+                    updateDecorations([...allCurrentTabsUris, ...closedTabsUris])
                 }),
             )
             return


### PR DESCRIPTION
Should close #20, but there is a bug to investigate, which I didn't manage to resolve myself :)

STR:
1. Set two editors to be kept open
2. Select first editor
3. Open new editor in preview mode

AR: 
Tab numbers don't match the `from left` order

<img width="424" alt="image" src="https://user-images.githubusercontent.com/74474615/189009914-9d0833d5-aea5-400a-ba31-8d95e2e288ae.png">

This is caused by binding the displayed tab number with it's order in tab list - I didn't manage finding the way how to update only the tab in preview mode without triggering other tabs numbers update. Any thoughts?
