### PR TITLE
feat(generateGitlabPush): generate `git push` with gitlab specific options

### DIFF
--- a/package.json
+++ b/package.json
@@ -263,6 +263,10 @@
             {
                 "command": "openReferencesInView",
                 "title": "Open References in View"
+            },
+            {
+                "command": "generateGitlabPush",
+                "title": "Generate push with gitlab options"
             }
         ],
         "configuration": {
@@ -468,6 +472,69 @@
                     "type": "boolean",
                     "description": "Wether to display statusbar with all occurences count (including selected) in the following format: E (case matching occurences)",
                     "default": false
+                },
+                "generateGitlabPush": {
+                    "type": "object",
+                    "description": "Generate `git push` with gitlab specific options",
+                    "properties": {
+                        "dynamicPushOptions": {
+                            "type": "object",
+                            "properties": {
+                                "merge_request.target": {
+                                    "type": "string"
+                                },
+                                "merge_request.title": {
+                                    "type": "string",
+                                    "default": ""
+                                },
+                                "merge_request.description": {
+                                    "type": "string",
+                                    "default": ""
+                                },
+                                "merge_request.milestone": {
+                                    "type": "string",
+                                    "default": ""
+                                },
+                                "merge_request.label": {
+                                    "type": "string",
+                                    "default": ""
+                                },
+                                "merge_request.unlabel": {
+                                    "type": "string",
+                                    "default": ""
+                                },
+                                "merge_request.assign": {
+                                    "type": "string",
+                                    "default": ""
+                                },
+                                "merge_request.unassign": {
+                                    "type": "string",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "staticPushOptions": {
+                            "type": "object",
+                            "properties": {
+                                "merge_request.create": {
+                                    "type": "boolean",
+                                    "default": false
+                                },
+                                "merge_request.merge_when_pipeline_succeeds":{
+                                    "type": "boolean",
+                                    "default": false
+                                },
+                                "merge_request.remove_source_branch": {
+                                    "type": "boolean",
+                                    "default": false
+                                },
+                                "merge_request.draft": {
+                                    "type": "boolean",
+                                    "default": false
+                                }
+                            }
+                        }
+                    }
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -267,6 +267,10 @@
             {
                 "command": "generateGitlabPush",
                 "title": "Generate push with gitlab options"
+            },
+            {
+                "command": "generateGitlabPushAccept",
+                "title": "Accept created push sequence"
             }
         ],
         "configuration": {
@@ -575,6 +579,10 @@
                 {
                     "command": "renameVariablePartsPartMoveDown",
                     "when": "false"
+                },
+                {
+                    "command": "generateGitlabPushAccept",
+                    "when": "false"
                 }
             ]
         },
@@ -620,6 +628,12 @@
                 "key": "ctrl+alt+k",
                 "mac": "cmd+shift+k",
                 "when": "zardoyExperiments.renameVariablePartsOpened"
+            },
+            {
+                "command": "zardoyExperiments.generateGitlabPushAccept",
+                "key": "ctrl+o",
+                "mac": "cmd+o",
+                "when": "zardoyExperiments.generateGitlabPushOpened"
             }
         ]
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -63,6 +63,7 @@ import tsHighlightedKeywordsReferences from './features/tsHighlightedKeywordsRef
 import autoRenameJsx from './features/autoRenameJsx'
 import openReferencesInView from './features/openReferencesInView'
 import statusbarOccurrencesCount from './features/statusbarOccurrencesCount'
+import generateGitlabPush from './features/generateGitlabPush'
 
 export const activate = () => {
     void initGitApi()
@@ -131,6 +132,7 @@ export const activate = () => {
     autoRenameJsx()
     openReferencesInView()
     statusbarOccurrencesCount()
+    generateGitlabPush()
 
     registerExtensionCommand('openUrl', async (_, url: string) => {
         // to test: https://regex101.com/?regex=.%2B%3A.%2B%3B?&flags=gi

--- a/src/features/generateGitlabPush.ts
+++ b/src/features/generateGitlabPush.ts
@@ -49,7 +49,10 @@ export default () => {
         }
 
         const updatePushOption = (option: string, value: string) => {
-            if (option in pushOptions.dynamicPushOptions) pushOptions.dynamicPushOptions[option] = value
+            if (option in pushOptions.dynamicPushOptions) {
+                if (!(value.startsWith('"') && value.endsWith('"'))) value = `"${value}"`
+                pushOptions.dynamicPushOptions[option] = value
+            }
         }
 
         const registerCommand = (command: keyof RegularCommands, handler: () => void) =>

--- a/src/features/generateGitlabPush.ts
+++ b/src/features/generateGitlabPush.ts
@@ -16,12 +16,20 @@ export default () => {
             dynamicPushOptions,
             staticPushOptions,
         }
+        const normallizeStaticOptions = staticOptions =>
+            Object.keys(staticOptions)
+                .map(key => ` -o ${key}`)
+                .join('')
+        const normallizeDynamicOptions = dynamicOption =>
+            Object.entries(dynamicOption)
+                .filter(([, value]) => value)
+                .map(([key, value]) => ` -o ${key}=${value}`)
+                .join('')
+
         const getOptionsNames = () => [...Object.keys(pushOptions.dynamicPushOptions), ...Object.keys(pushOptions.staticPushOptions)]
 
         const updateMainTitle = () => {
-            quickPick.title = `git push ${normallizeDynamicOptions(pushOptions.dynamicPushOptions)} -o ${normallizeStaticOptions(
-                pushOptions.staticPushOptions,
-            )}`
+            quickPick.title = `git push${normallizeDynamicOptions(pushOptions.dynamicPushOptions)}${normallizeStaticOptions(pushOptions.staticPushOptions)}`
         }
 
         const setActiveItem = (existingIndex: number) => {
@@ -32,18 +40,13 @@ export default () => {
         }
 
         const resetItems = () => {
-            quickPick.items = [...Object.keys(pushOptions.dynamicPushOptions), ...Object.keys(pushOptions.staticPushOptions)].map(option => ({ label: option }))
+            // Currently remove static options from quick pick as managing them looks tricky
+            // quickPick.items = [...Object.keys(pushOptions.dynamicPushOptions), ...Object.keys(pushOptions.staticPushOptions)].map(option => ({ label: option }))
+            quickPick.items = Object.keys(pushOptions.dynamicPushOptions).map(option => ({ label: option }))
             if (editingIndex !== undefined) setActiveItem(editingIndex)
             updateMainTitle()
             editingIndex = undefined
         }
-
-        const normallizeStaticOptions = staticOptions => Object.keys(staticOptions).join(' -o ')
-        const normallizeDynamicOptions = dynamicOption =>
-            Object.entries(dynamicOption)
-                .filter(([, value]) => value)
-                .map(([key, value]) => `-o ${key}=${value}`)
-                .join(' ')
 
         const updatePushOption = (option: string, value: string) => {
             if (option in pushOptions.dynamicPushOptions) pushOptions.dynamicPushOptions[option] = value

--- a/src/features/generateGitlabPush.ts
+++ b/src/features/generateGitlabPush.ts
@@ -1,0 +1,101 @@
+import * as vscode from 'vscode'
+import { getExtensionContributionsPrefix, getExtensionSetting, registerExtensionCommand, RegularCommands } from 'vscode-framework'
+
+export default () => {
+    registerExtensionCommand('generateGitlabPush', async () => {
+        // https://docs.gitlab.com/ee/user/project/push_options.html
+
+        const quickPick = vscode.window.createQuickPick()
+
+        const dynamicPushOptions = getExtensionSetting('generateGitlabPush.dynamicPushOptions') as Record<string, string>
+        const staticPushOptions = getExtensionSetting('generateGitlabPush.staticPushOptions') as Record<string, boolean>
+
+        let editingIndex: number | undefined
+
+        const pushOptions = {
+            dynamicPushOptions,
+            staticPushOptions,
+        }
+        const getOptionsNames = () => [...Object.keys(pushOptions.dynamicPushOptions), ...Object.keys(pushOptions.staticPushOptions)]
+
+        const updateMainTitle = () => {
+            quickPick.title = `git push ${normallizeDynamicOptions(pushOptions.dynamicPushOptions)} -o ${normallizeStaticOptions(
+                pushOptions.staticPushOptions,
+            )}`
+        }
+
+        const setActiveItem = (existingIndex: number) => {
+            // do it in next loop after items update (most probably)
+            setTimeout(() => {
+                quickPick.activeItems = [quickPick.items[existingIndex]!]
+            })
+        }
+
+        const resetItems = () => {
+            quickPick.items = [...Object.keys(pushOptions.dynamicPushOptions), ...Object.keys(pushOptions.staticPushOptions)].map(option => ({ label: option }))
+            if (editingIndex !== undefined) setActiveItem(editingIndex)
+            updateMainTitle()
+            editingIndex = undefined
+        }
+
+        const normallizeStaticOptions = staticOptions => Object.keys(staticOptions).join(' -o ')
+        const normallizeDynamicOptions = dynamicOption =>
+            Object.entries(dynamicOption)
+                .filter(([, value]) => value)
+                .map(([key, value]) => `-o ${key}=${value}`)
+                .join(' ')
+
+        const updatePushOption = (option: string, value: string) => {
+            if (option in pushOptions.dynamicPushOptions) pushOptions.dynamicPushOptions[option] = value
+        }
+
+        const registerCommand = (command: keyof RegularCommands, handler: () => void) =>
+            vscode.commands.registerCommand(`${getExtensionContributionsPrefix()}${command}`, handler)
+
+        const mainDisposable = vscode.Disposable.from(
+            quickPick,
+            registerCommand('generateGitlabPushAccept', () => {
+                if (!quickPick.title) return
+
+                const terminal = vscode.window.createTerminal()
+                terminal.sendText(quickPick.title)
+                terminal.show()
+                // dispose terminal in success cases?
+                // terminal.dispose()
+            }),
+            {
+                dispose() {
+                    void vscode.commands.executeCommand('setContext', 'zardoyExperiments.generateGitlabPushOpened', false)
+                },
+            },
+        )
+
+        quickPick.onDidAccept(() => {
+            const activeItem = quickPick.activeItems[0]!
+            if (editingIndex === undefined) {
+                if (!activeItem) return
+                editingIndex = quickPick.items.indexOf(activeItem)
+                const { label } = activeItem
+                const editingOption = [...Object.entries(pushOptions.dynamicPushOptions), ...Object.entries(pushOptions.dynamicPushOptions)].find(
+                    ([option, value]) => option === label,
+                )!
+                quickPick.items = []
+                quickPick.title = `Changing option: ${label}`
+                quickPick.value = editingOption[1]
+                return
+            }
+
+            const changingOption = getOptionsNames()[editingIndex]!
+            updatePushOption(changingOption, quickPick.value)
+            resetItems()
+            quickPick.value = ''
+        })
+
+        quickPick.onDidHide(() => {
+            mainDisposable.dispose()
+        })
+        await vscode.commands.executeCommand('setContext', 'zardoyExperiments.generateGitlabPushOpened', true)
+        resetItems()
+        quickPick.show()
+    })
+}


### PR DESCRIPTION
MR generation without even opening gitab! (in some cases :) )

This version is limited a bit as you can't enable/disable static push options from quick pick menu, but I don't think one might wanna change them often.