### PR TITLE
fix(tabsWithNumbers): correctly update closed tab

### DIFF
--- a/src/features/tabsWithNumbers.ts
+++ b/src/features/tabsWithNumbers.ts
@@ -48,21 +48,15 @@ export default () => {
         const humanReadableMode = noCase(mode)
 
         class FileDecorationProvider implements vscode.FileDecorationProvider {
-            listeners: Array<(e: vscode.Uri | vscode.Uri[] | undefined) => any> = []
+            eventEmitter = new vscode.EventEmitter<vscode.Uri | vscode.Uri[] | undefined>()
+            onDidChangeFileDecorations = this.eventEmitter.event
 
             constructor() {
                 subscribe(recentFileStack, ops => {
-                    for (const listener of this.listeners) listener(recentFileStack)
+                    this.eventEmitter.fire(recentFileStack)
                 })
                 updateDecorations = uris => {
-                    for (const listener of this.listeners) listener(uris ?? recentFileStack)
-                }
-            }
-
-            onDidChangeFileDecorations: vscode.Event<vscode.Uri | vscode.Uri[] | undefined> | undefined = listener => {
-                this.listeners.push(listener)
-                return {
-                    dispose() {},
+                    this.eventEmitter.fire(uris ?? recentFileStack)
                 }
             }
 

--- a/src/features/tabsWithNumbers.ts
+++ b/src/features/tabsWithNumbers.ts
@@ -52,8 +52,7 @@ export default () => {
 
             constructor() {
                 subscribe(recentFileStack, ops => {
-                    const deletedUris = compact(ops.map(([operation, _affectedIndexes, uri]) => (operation === 'delete' ? (uri as vscode.Uri) : undefined)))
-                    for (const listener of this.listeners) listener([...recentFileStack, ...deletedUris])
+                    for (const listener of this.listeners) listener(recentFileStack)
                 })
                 updateDecorations = uris => {
                     for (const listener of this.listeners) listener(uris ?? recentFileStack)

--- a/src/features/tabsWithNumbers.ts
+++ b/src/features/tabsWithNumbers.ts
@@ -29,7 +29,6 @@ export default () => {
                 }
 
                 const index = number - 1
-                console.log('focus', number)
                 if (mode === 'fromLeft') await focusTabFromLeft(index)
                 // eslint-disable-next-line sonarjs/no-duplicate-string
                 const tabUriToFocus = (getExtensionSetting('showTabNumbers.reversedMode') ? [...recentFileStack].reverse() : recentFileStack)[index]
@@ -143,6 +142,7 @@ export default () => {
                 const elemIndex = recentFileStack.findIndex(tabUri => tabUri.toString() === document.uri.toString())
                 if (elemIndex === -1) return
                 recentFileStack.splice(elemIndex, 1)
+                updateDecorations([document.uri])
             }),
         )
     }


### PR DESCRIPTION
There is a bug with closing tabs: 
![Peek 2022-11-26 23-34](https://user-images.githubusercontent.com/74474615/204108025-d8ea3d2c-7fcb-4188-97d7-3656d0b43804.gif)

This happens because deleting tab Uri doesn't present in `valtio`'s `delete` operations array [here](https://github.com/zardoy/vscode-experiments/blob/main/src/features/tabsWithNumbers.ts#L55-L58), so we don't update its decoration.

This example may help better understand the issue:
```js
import { proxy, subscribe } from 'valtio/vanilla'

const array = proxy(['delete', 'first', 'second'])
const updateArray = (ops) => console.log('opts', ops); 

subscribe(array, updateArray)

array.splice(0, 1)

console.log('ResultArray', array);
```
The log result is: 
```sh
ResultArray [ 'first', 'second' ]
ops [
  [ 'set', [ '0' ], 'first', 'delete' ],
  [ 'set', [ '1' ], 'second', 'first' ],
  [ 'delete', [ '2' ], 'second' ],
  [ 'set', [ 'length' ], 2, 3 ]
]
```
It doesn't look very clear, but the thing is - we replace array elements with new ones by indices and actually delete only the last one
