### PR TITLE
feat(command): focus semantic server output

### DIFF
--- a/package.json
+++ b/package.json
@@ -221,6 +221,10 @@
                 "title": "Toggle Extension Host Output"
             },
             {
+                "command": "toggleVueSemanticServerOutput",
+                "title": "Toggle Vue Semantic Server Output"
+            },
+            {
                 "command": "openCompletionKindPlayground",
                 "title": "Open Completion Kind Playground"
             },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,6 +47,7 @@ import applyCreatedCodeTransformers from './features/applyCreatedCodeTransformer
 import newTerminalWithSameCwd from './features/newTerminalWithSameCwd'
 import vscodeDevCompletions from './features/vscodeDevCompletions'
 import toggleExtHostOutput from './features/toggleExtHostOutput'
+import toggleVueSemanticServerOutput from './features/toggleVueSemanticServerOutput'
 import completionsKindPlayground from './features/completionsKindPlayground'
 import autoEscapeJson from './features/autoEscapeJson'
 import gitStageQuickPick from './features/gitStageQuickPick'
@@ -118,6 +119,7 @@ export const activate = () => {
     newTerminalWithSameCwd()
     vscodeDevCompletions()
     toggleExtHostOutput()
+    toggleVueSemanticServerOutput()
     completionsKindPlayground()
     autoEscapeJson()
     gitStageQuickPick()

--- a/src/features/tabsWithNumbers.ts
+++ b/src/features/tabsWithNumbers.ts
@@ -120,6 +120,7 @@ export default () => {
         disposables.push(
             vscode.window.onDidChangeActiveTextEditor(textEditor => {
                 if (!textEditor || textEditor.viewColumn === undefined) return
+
                 const { uri } = textEditor.document
                 if (uri.scheme === 'search-editor') return
 

--- a/src/features/tabsWithNumbers.ts
+++ b/src/features/tabsWithNumbers.ts
@@ -66,7 +66,7 @@ export default () => {
                     ({
                         numberOnly: `${tabNumber}`,
                         numberWithPrefix: `t${tabNumber}`,
-                    }[getExtensionSetting('showTabNumbers.badgeText')])
+                    })[getExtensionSetting('showTabNumbers.badgeText')]
 
                 if (!isByRecentMode) {
                     const { tabs } = vscode.window.tabGroups.activeTabGroup

--- a/src/features/toggleVueSemanticServerOutput.ts
+++ b/src/features/toggleVueSemanticServerOutput.ts
@@ -1,0 +1,8 @@
+import * as vscode from 'vscode'
+import { registerExtensionCommand } from 'vscode-framework'
+
+export default () => {
+    registerExtensionCommand('toggleVueSemanticServerOutput', async () => {
+        await vscode.commands.executeCommand('workbench.output.action.switchBetweenOutputs', 'extension-output-Vue.volar-#1-Vue Semantic Server')
+    })
+}


### PR DESCRIPTION
@zardoy This command works as expected on my side, but maybe there is a better way to focus output? As I can see the output name generates [here](https://github.com/microsoft/vscode/blob/e55c82224d9a0b3c89226f81c1f29c87bbd561e9/src/vs/workbench/api/browser/mainThreadOutputService.ts#L47C3-L47C3) and looks like it could change occasionally :/

Btw  I got output name by logging `vscode.window.activeTextEditor?.document.fileName` when Vue Semantic Server output was focused